### PR TITLE
fixed null exception with new DLC

### DIFF
--- a/Source/Vanya_ShieldBelt/Harmony/PatchMain.cs
+++ b/Source/Vanya_ShieldBelt/Harmony/PatchMain.cs
@@ -1,0 +1,16 @@
+﻿using Verse;
+using HarmonyLib;
+using System.Reflection;
+
+namespace Vanya_ShieldBelt
+{
+    [StaticConstructorOnStartup]
+    public class PatchMain
+    {
+        static PatchMain()
+        {
+            Harmony instance = new Harmony("Vanya_ShieldBelt");
+            instance.PatchAll(Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/Source/Vanya_ShieldBelt/Harmony/PatchSimulateKilled.cs
+++ b/Source/Vanya_ShieldBelt/Harmony/PatchSimulateKilled.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+using static Verse.DamageWorker;
+
+namespace Vanya_ShieldBelt
+{
+    [HarmonyPatch(typeof(HealthUtility), "SimulateKilled")]
+    public class PatchTest
+    {
+        [HarmonyPrefix]
+        public static void prefix(Pawn p, DamageDef damage, ThingDef sourceDef, Tool sourceTool)
+        {
+            List<Apparel> wornApparel = p.apparel.WornApparel.ToList();
+            for (int i = 0; i < wornApparel.Count; ++i)
+            {
+                if (wornApparel[i] is VanyaMod.Vanya_ShieldBelt)
+                {
+                    p.apparel.Remove(wornApparel[i]);
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Thing), "TakeDamage")]
+    public class Patchtkdmg
+    {
+        [HarmonyPostfix]
+        public static void post(DamageInfo dinfo, ref DamageResult __result)
+        {
+            if (__result.hediffs == null) __result.hediffs = new List<Hediff>();
+        }
+
+    }
+}


### PR DESCRIPTION
Greetings. A null exception may occur when "Obelisk Abductor" go active and generating a new special map.
Directly function with exception is Verse.HealthUtility.SimulateKilled.
Found the reason is that, during that process, the vanilla game generates and kill some new pawns. However, those new pawns may spawn with vanya shield, so the damage given may be shielded. Finally, the vanilla wants to give damage source info or something to hediffs made by the damage mentioned above which did not exist, and the list for those hediffs(DamageWorker.DamageResult.hediffs) is null, not a list with 0 elements.

Two solutions offered by this PR, while any one of them can solve this bug alone.
The first is, remove all vanya shields before kill those pawns to ensure the damage may no long be absorb; the second is, make a new list just after take damage, so the list used by the enumerator is a list has 0 element, not a null.